### PR TITLE
Ensure error path is an array

### DIFF
--- a/lib/operations/components/base.rb
+++ b/lib/operations/components/base.rb
@@ -37,7 +37,7 @@ class Operations::Components::Base
     messages = Array.wrap(data).map do |datum|
       message_resolver.call(
         message: datum[:message],
-        path: datum[:path] || [nil],
+        path: Array.wrap(datum[:path] || [nil]),
         tokens: datum[:tokens] || {},
         meta: datum[:meta] || {}
       )


### PR DESCRIPTION
I noticed that we might pass just a symbol as path by mistake. Later it will cause issues with message rendering.