### PR TITLE
Introduce idempotency checks

### DIFF
--- a/lib/operations.rb
+++ b/lib/operations.rb
@@ -11,6 +11,7 @@ require "active_support/inflector/inflections"
 require "active_model/naming"
 require "operations/version"
 require "operations/types"
+require "operations/configuration"
 require "operations/contract"
 require "operations/contract/messages_resolver"
 require "operations/convenience"
@@ -20,9 +21,26 @@ require "operations/form"
 require "operations/form/attribute"
 require "operations/form/builder"
 
-# Dry::Schema.load_extensions(:monads)
-# Dry::Validation.load_extensions(:monads)
+# The root gem module
+module Operations
+  class Error < StandardError
+  end
 
-# Your code goes here...
-class Operations::Error < StandardError
+  DEFAULT_ERROR_REPORTER = lambda do |message, payload|
+    Sentry.capture_message(message, extra: payload)
+  end
+  DEFAULT_TRANSACTION = ->(&block) { ActiveRecord::Base.transaction(&block) }
+
+  class << self
+    attr_reader :default_config
+
+    def configure(**options)
+      @default_config = Configuration.new(**options)
+    end
+  end
+
+  configure(
+    error_reporter: DEFAULT_ERROR_REPORTER,
+    transaction: DEFAULT_TRANSACTION
+  )
 end

--- a/lib/operations/command.rb
+++ b/lib/operations/command.rb
@@ -95,12 +95,12 @@ require "operations/components/after"
 #    should be implemented as a precondition.
 # 4. Idempotency check are running after preconditions and can return
 #    either Success() or Failure({}). In case of Failure, the operation
-#    body (and after calls) will be skept but the operatiuon result will
+#    body (and after calls) will be skept but the operation result will
 #    be successful. Failure({}) can carry an additional context to make
-#    sure the opreation result context is going to be the same for case
-#    or normal operation execution and skipped operation body. The only
-#    sign of the execution interrupted atthis stage will be the value
-#    of {Result#component} equal to `:idempotency`.
+#    sure the operation result context is going to be the same for both
+#    cases of normal operation execution and skipped operation body. The
+#    only sign of the execution interrupted at this stage will be the
+#    value of {Result#component} equal to `:idempotency`.
 # 5. Operation itself implements the routine. It can create or update
 #    enities, send API requiests, send notifications, communicate with
 #    the bus. Anything that should be done as a part of the operation.

--- a/lib/operations/command.rb
+++ b/lib/operations/command.rb
@@ -116,10 +116,6 @@ class Operations::Command
   EMPTY_HASH = {}.freeze
   COMPONENTS = %i[contract policies preconditions operation after].freeze
   FORM_HYDRATOR = ->(_form_class, params, **_context) { params }
-  ERROR_REPORTER = lambda do |message, payload|
-    Sentry.capture_message(message, extra: payload)
-  end
-  TRANSACTION = ->(&block) { ActiveRecord::Base.transaction(&block) }
 
   include Dry::Monads[:result]
   include Dry::Monads::Do.for(:call_monad, :callable_monad, :validate_monad)
@@ -143,8 +139,8 @@ class Operations::Command
   option :form_base, Operations::Types::Class, default: proc { ::Operations::Form }
   option :form_class, Operations::Types::Class, default: proc { build_form }
   option :form_hydrator, Operations::Types.Interface(:call), default: proc { FORM_HYDRATOR }
-  option :error_reporter, Operations::Types.Interface(:call), default: proc { ERROR_REPORTER }
-  option :transaction, Operations::Types.Interface(:call), default: proc { TRANSACTION }
+  option :error_reporter, Operations::Types.Interface(:call), default: proc { Operations.default_config.error_reporter }
+  option :transaction, Operations::Types.Interface(:call), default: proc { Operations.default_config.transaction }
 
   # A short-cut to initialize operation by convention:
   #

--- a/lib/operations/command.rb
+++ b/lib/operations/command.rb
@@ -93,14 +93,22 @@ require "operations/components/after"
 #    on the context (either initial or the data loaded by the contract).
 #    Anything that has nothing to do with the user input validation
 #    should be implemented as a precondition.
-# 4. Operation itself implements the routine. It can create or update
+# 4. Idempotency check are running after preconditions and can return
+#    either Success() or Failure({}). In case of Failure, the operation
+#    body (and after calls) will be skept but the operatiuon result will
+#    be successful. Failure({}) can carry an additional context to make
+#    sure the opreation result context is going to be the same for case
+#    or normal operation execution and skipped operation body. The only
+#    sign of the execution interrupted atthis stage will be the value
+#    of {Result#component} equal to `:idempotency`.
+# 5. Operation itself implements the routine. It can create or update
 #    enities, send API requiests, send notifications, communicate with
 #    the bus. Anything that should be done as a part of the operation.
 #    Operation returns a Result monad (either Success or Failure).
 #    See {https://dry-rb.org/gems/dry-monads/1.3/} for details. Also,
 #    it is better to use Do notation for the implementation. If Success
 #    result contains a hash, it is returned as a part of the context.
-# 5. After calls run after the operation was successful and transaction
+# 6. After calls run after the operation was successful and transaction
 #    was committed. Composite adds the result of the after calls to the
 #    operation result but in case of unsuccessful after calls, the
 #    operation is still marked as successful. Each particular after

--- a/lib/operations/components/after.rb
+++ b/lib/operations/components/after.rb
@@ -44,7 +44,7 @@ class Operations::Components::After < Operations::Components::Base
 
   def maybe_report_failure(result)
     if result.after.any?(Failure)
-      error_reporter.call(
+      error_reporter&.call(
         "Operation side-effects went sideways",
         result: result.pretty_inspect
       )

--- a/lib/operations/components/base.rb
+++ b/lib/operations/components/base.rb
@@ -8,7 +8,8 @@ class Operations::Components::Base
 
   param :callable, type: Operations::Types.Interface(:call)
   option :message_resolver, type: Operations::Types.Interface(:call), optional: true
-  option :error_reporter, type: Operations::Types.Interface(:call), optional: true
+  option :info_reporter, type: Operations::Types::Nil | Operations::Types.Interface(:call), optional: true
+  option :error_reporter, type: Operations::Types::Nil | Operations::Types.Interface(:call), optional: true
   option :transaction, type: Operations::Types.Interface(:call), optional: true
 
   private

--- a/lib/operations/components/idempotency.rb
+++ b/lib/operations/components/idempotency.rb
@@ -22,7 +22,7 @@ class Operations::Components::Idempotency < Operations::Components::Prechecks
     if failure
       new_result = result(
         params: params,
-        context: context.merge(failure.failure || {})
+        context: context.merge(failure.failure)
       )
 
       report_failure(new_result, failed_check)

--- a/lib/operations/components/idempotency.rb
+++ b/lib/operations/components/idempotency.rb
@@ -17,7 +17,7 @@ require "operations/components/prechecks"
 # Component logs the failed check with `error_reporter`.
 class Operations::Components::Idempotency < Operations::Components::Prechecks
   def call(params, context)
-    failure, failed_check = process_callables(context)
+    failure, failed_check = process_callables(params, context)
 
     if failure
       new_result = result(
@@ -38,12 +38,12 @@ class Operations::Components::Idempotency < Operations::Components::Prechecks
 
   private
 
-  def process_callables(context)
+  def process_callables(params, context)
     failed_check = nil
     failure = nil
 
     callable.each do |entry|
-      result = entry.call(**context)
+      result = entry.call(params, **context)
 
       case result
       when Failure

--- a/lib/operations/components/idempotency.rb
+++ b/lib/operations/components/idempotency.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "operations/components/prechecks"
+
+# Contains logic to handle idempotency checks.
+#
+# Idempotency checks are used to skip operation execution in
+# certain conditions.
+#
+# An idempotency check returns a Result monad. If it returns
+# a Failure, the operation body is skipped but the operation
+# is considered successful. The value or failure will be merged
+# to the result context in order to enrich it (the failure should
+# contain something that operation body would return normally
+# to mimic a proper operation call result).
+#
+# Component logs the failed check with `error_reporter`.
+class Operations::Components::Idempotency < Operations::Components::Prechecks
+  def call(params, context)
+    failure, failed_check = process_callables(context)
+
+    if failure
+      new_result = result(
+        params: params,
+        context: context.merge(failure.failure || {})
+      )
+
+      report_failure(new_result, failed_check)
+
+      Failure(new_result)
+    else
+      Success(result(
+        params: params,
+        context: context
+      ))
+    end
+  end
+
+  private
+
+  def process_callables(context)
+    failed_check = nil
+    failure = nil
+
+    callable.each do |entry|
+      result = entry.call(**context)
+
+      case result
+      when Failure
+        failed_check = entry
+        failure = result
+        break
+      when Success
+        next
+      else
+        raise "Unrecognizer result of an idempotency check. Expected Result monad, got #{result.class}"
+      end
+    end
+
+    [failure, failed_check]
+  end
+
+  def report_failure(result, failed_check)
+    info_reporter&.call(
+      "Idempotency check failed",
+      result: result.pretty_inspect,
+      failed_check: failed_check.pretty_inspect
+    )
+  end
+end

--- a/lib/operations/components/idempotency.rb
+++ b/lib/operations/components/idempotency.rb
@@ -53,7 +53,7 @@ class Operations::Components::Idempotency < Operations::Components::Prechecks
       when Success
         next
       else
-        raise "Unrecognizer result of an idempotency check. Expected Result monad, got #{result.class}"
+        raise "Unrecognized result of an idempotency check. Expected Result monad, got #{result.class}"
       end
     end
 

--- a/lib/operations/configuration.rb
+++ b/lib/operations/configuration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# The framework's configuration shared between all the commands.
+#
+# @see Operations.default_config
+class Operations::Configuration
+  extend Dry::Initializer
+
+  option :error_reporter, Operations::Types.Interface(:call)
+  option :transaction, Operations::Types.Interface(:call)
+end

--- a/lib/operations/configuration.rb
+++ b/lib/operations/configuration.rb
@@ -9,4 +9,8 @@ class Operations::Configuration
   option :info_reporter, Operations::Types.Interface(:call), optional: true
   option :error_reporter, Operations::Types.Interface(:call), optional: true
   option :transaction, Operations::Types.Interface(:call)
+
+  def to_h
+    self.class.dry_initializer.attributes(self)
+  end
 end

--- a/lib/operations/configuration.rb
+++ b/lib/operations/configuration.rb
@@ -6,6 +6,7 @@
 class Operations::Configuration
   extend Dry::Initializer
 
-  option :error_reporter, Operations::Types.Interface(:call)
+  option :info_reporter, Operations::Types.Interface(:call), optional: true
+  option :error_reporter, Operations::Types.Interface(:call), optional: true
   option :transaction, Operations::Types.Interface(:call)
 end

--- a/spec/operations/command_spec.rb
+++ b/spec/operations/command_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe Operations::Command do
 
     context "when idempotency check failed" do
       let(:context) { { admin: true, error: nil } }
-      let(:idempotency_checks) { [->(**) { Dry::Monads::Failure(additional: :value) }] }
+      let(:idempotency_checks) { [->(_, **) { Dry::Monads::Failure(additional: :value) }] }
       let(:operation) { ->(**) { raise } }
 
       it "returns a successful result and stops on idempotency check stage" do

--- a/spec/operations/command_spec.rb
+++ b/spec/operations/command_spec.rb
@@ -453,12 +453,12 @@ RSpec.describe Operations::Command do
     let(:context) { { admin: true, error: nil } }
     let(:params) { { name: "TEST" } }
 
-    it { is_expected.to eq true }
+    it { is_expected.to be true }
 
     context "when check failed" do
       let(:params) { { name: nil } }
 
-      it { is_expected.to eq false }
+      it { is_expected.to be false }
     end
   end
 
@@ -549,10 +549,10 @@ RSpec.describe Operations::Command do
     context "when check failed" do
       let(:context) { { admin: false } }
 
-      it { is_expected.to eq false }
+      it { is_expected.to be false }
     end
 
-    it { is_expected.to eq true }
+    it { is_expected.to be true }
   end
 
   describe "#allowed" do
@@ -604,10 +604,10 @@ RSpec.describe Operations::Command do
     context "when check failed" do
       let(:context) { { admin: false } }
 
-      it { is_expected.to eq false }
+      it { is_expected.to be false }
     end
 
-    it { is_expected.to eq true }
+    it { is_expected.to be true }
   end
 
   describe "#possible" do
@@ -656,9 +656,9 @@ RSpec.describe Operations::Command do
     context "when check failed" do
       let(:context) { { error: "Error" } }
 
-      it { is_expected.to eq false }
+      it { is_expected.to be false }
     end
 
-    it { is_expected.to eq true }
+    it { is_expected.to be true }
   end
 end

--- a/spec/operations/components/idempotency_spec.rb
+++ b/spec/operations/components/idempotency_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Operations::Components::Idempotency do
+  subject(:component) { described_class.new(idempotency_checks) }
+
+  let(:idempotency_checks) { [->(**) { Dry::Monads::Success(unused: :value) }] }
+
+  describe "#call" do
+    subject(:call) { component.call(params, context) }
+
+    let(:params) { { name: "Batman" } }
+    let(:context) { { subject: 42 } }
+
+    context "with idempotency checks failure" do
+      let(:idempotency_checks) do
+        [
+          ->(**) { Dry::Monads::Success() },
+          ->(**) { Dry::Monads::Failure(additional: :value) }
+        ]
+      end
+
+      it "returns a failure result" do
+        expect(call)
+          .to be_failure
+          .and have_attributes(
+            failure: have_attributes(
+              component: :idempotency,
+              params: { name: "Batman" },
+              context: { subject: 42, additional: :value },
+              after: [],
+              errors: be_empty
+            )
+          )
+      end
+    end
+
+    context "when no idempotency checks" do
+      let(:idempotency_checks) { [] }
+
+      it "returns a successful result" do
+        expect(call)
+          .to be_success
+          .and have_attributes(
+            value!: have_attributes(
+              component: :idempotency,
+              params: { name: "Batman" },
+              context: { subject: 42 },
+              after: [],
+              errors: be_empty
+            )
+          )
+      end
+    end
+
+    it "returns a successful result" do
+      expect(call)
+        .to be_success
+        .and have_attributes(
+          value!: have_attributes(
+            component: :idempotency,
+            params: { name: "Batman" },
+            context: { subject: 42 },
+            after: [],
+            errors: be_empty
+          )
+        )
+    end
+  end
+end

--- a/spec/operations/components/idempotency_spec.rb
+++ b/spec/operations/components/idempotency_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Operations::Components::Idempotency do
   subject(:component) { described_class.new(idempotency_checks, info_reporter: info_reporter) }
 
-  let(:idempotency_checks) { [->(**) { Dry::Monads::Success(unused: :value) }] }
+  let(:idempotency_checks) { [->(_, **) { Dry::Monads::Success(unused: :value) }] }
   let(:info_reporter) { instance_double(Proc) }
 
   before { allow(info_reporter).to receive(:call) }
@@ -17,8 +17,8 @@ RSpec.describe Operations::Components::Idempotency do
     context "with idempotency checks failure" do
       let(:idempotency_checks) do
         [
-          ->(**) { Dry::Monads::Success() },
-          ->(**) { Dry::Monads::Failure(additional: :value) }
+          ->(_, **) { Dry::Monads::Success() },
+          ->(_, **) { Dry::Monads::Failure(additional: :value) }
         ]
       end
 

--- a/spec/operations/components/idempotency_spec.rb
+++ b/spec/operations/components/idempotency_spec.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Operations::Components::Idempotency do
-  subject(:component) { described_class.new(idempotency_checks) }
+  subject(:component) { described_class.new(idempotency_checks, info_reporter: info_reporter) }
 
   let(:idempotency_checks) { [->(**) { Dry::Monads::Success(unused: :value) }] }
+  let(:info_reporter) { instance_double(Proc) }
+
+  before { allow(info_reporter).to receive(:call) }
 
   describe "#call" do
     subject(:call) { component.call(params, context) }
@@ -31,6 +34,7 @@ RSpec.describe Operations::Components::Idempotency do
               errors: be_empty
             )
           )
+        expect(info_reporter).to have_received(:call)
       end
     end
 
@@ -49,6 +53,7 @@ RSpec.describe Operations::Components::Idempotency do
               errors: be_empty
             )
           )
+        expect(info_reporter).not_to have_received(:call)
       end
     end
 
@@ -64,6 +69,7 @@ RSpec.describe Operations::Components::Idempotency do
             errors: be_empty
           )
         )
+      expect(info_reporter).not_to have_received(:call)
     end
   end
 end

--- a/spec/operations/configuration_spec.rb
+++ b/spec/operations/configuration_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Operations::Configuration do
-  subject(:configuration) { Operations::Configuration.new(**options) }
+  subject(:configuration) { described_class.new(**options) }
 
-  let(:error_reporter) { ->() {} }
-  let(:transaction) { ->() {} }
+  let(:error_reporter) { -> {} }
+  let(:transaction) { -> {} }
   let(:options) { { error_reporter: error_reporter, transaction: transaction } }
 
-  describe '#to_h' do
+  describe "#to_h" do
     subject(:to_h) { configuration.to_h }
 
     it { is_expected.to eq(error_reporter: error_reporter, transaction: transaction) }

--- a/spec/operations/configuration_spec.rb
+++ b/spec/operations/configuration_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Operations::Configuration do
+  subject(:configuration) { Operations::Configuration.new(options) }
+
+  let(:error_reporter) { ->() {} }
+  let(:transaction) { ->() {} }
+  let(:options) { { error_reporter: error_reporter, transaction: transaction } }
+
+  describe '#to_h' do
+    subject(:to_h) { configuration.to_h }
+
+    it { is_expected.to eq(error_reporter: error_reporter, transaction: transaction) }
+  end
+end

--- a/spec/operations/configuration_spec.rb
+++ b/spec/operations/configuration_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Operations::Configuration do
-  subject(:configuration) { Operations::Configuration.new(options) }
+  subject(:configuration) { Operations::Configuration.new(**options) }
 
   let(:error_reporter) { ->() {} }
   let(:transaction) { ->() {} }

--- a/spec/operations_spec.rb
+++ b/spec/operations_spec.rb
@@ -4,4 +4,13 @@ RSpec.describe Operations do
   it "has a version number" do
     expect(Operations::VERSION).not_to be nil
   end
+
+  describe "#default_config" do
+    it "returns the default default_config values by default" do
+      expect(described_class.default_config).to have_attributes(
+        error_reporter: Operations::DEFAULT_ERROR_REPORTER,
+        transaction: Operations::DEFAULT_TRANSACTION
+      )
+    end
+  end
 end

--- a/spec/operations_spec.rb
+++ b/spec/operations_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Operations do
   it "has a version number" do
-    expect(Operations::VERSION).not_to be nil
+    expect(Operations::VERSION).not_to be_nil
   end
 
   describe "#default_config" do


### PR DESCRIPTION
Idempotency checks are used to skip operation execution in certain conditions.