### PR TITLE
Fix compatibility with the new dry-config

### DIFF
--- a/lib/operations/convenience.rb
+++ b/lib/operations/convenience.rb
@@ -77,8 +77,9 @@ module Operations::Convenience
   end
 
   def contract(prefix = nil, from: OperationContract, &block)
-    contract = Class.new(from, &block)
+    contract = Class.new(from)
     contract.config.messages.namespace = name.underscore
+    contract.class_eval(&block)
     const_set("#{prefix.to_s.camelize}Contract", contract)
   end
 

--- a/spec/operations/convenience_spec.rb
+++ b/spec/operations/convenience_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Operations::Convenience do
-  let(:dummy_operation) do
+  let(:dummy_command) do
     Class.new do
       def initialize(arg)
         @arg = arg
@@ -16,30 +16,53 @@ RSpec.describe Operations::Convenience do
       end
     end
   end
-  let(:dummy_class) do
+  let(:dummy_operation) do
     Class.new do
       extend Operations::Convenience
 
       def self.default(arg)
-        DummyOperation.new(arg)
+        DummyCommand.new(arg)
       end
     end
   end
 
-  before { stub_const("DummyOperation", dummy_operation) }
+  before do
+    stub_const("DummyCommand", dummy_command)
+    stub_const("DummyOperation", dummy_operation)
+  end
 
   describe "#method_missing" do
     specify do
-      expect(dummy_class.default(42).call(43)).to eq(call: [42, 43])
-      expect(dummy_class.default!(42).call(43)).to eq(call!: [42, 43])
+      expect(dummy_operation.default(42).call(43)).to eq(call: [42, 43])
+      expect(dummy_operation.default!(42).call(43)).to eq(call!: [42, 43])
     end
   end
 
   describe "#respond_to_missing?" do
     specify do
-      expect(dummy_class).to respond_to(:default)
-      expect(dummy_class).to respond_to(:default!)
-      expect(dummy_class).not_to respond_to(:foobar!)
+      expect(dummy_operation).to respond_to(:default)
+      expect(dummy_operation).to respond_to(:default!)
+      expect(dummy_operation).not_to respond_to(:foobar!)
+    end
+  end
+
+  describe "#contract" do
+    subject(:contract) do
+      dummy_operation.contract do
+        schema do
+          required(:name).filled(:string)
+        end
+      end
+    end
+
+    let(:operation_contract_class) { Class.new(Operations::Contract) }
+
+    before { stub_const("OperationContract", operation_contract_class) }
+
+    specify do
+      expect(contract).to eq(DummyOperation::Contract)
+      expect(contract.config.messages.namespace).to eq("dummy_operation")
+      expect(contract.schema.key_map.keys.map(&:name)).to eq([:name])
     end
   end
 end


### PR DESCRIPTION
Fixes 

```
Dry::Configurable::FrozenConfig:
  Cannot modify frozen config
```

The configuration should be done before the contract is defined, otherwise it is frozen.