### PR TITLE
Allow operation params as the first argument

### DIFF
--- a/lib/operations/components/operation.rb
+++ b/lib/operations/components/operation.rb
@@ -4,9 +4,18 @@ require "operations/components/base"
 
 # Wraps operation component call to adapt to the further processing.
 class Operations::Components::Operation < Operations::Components::Base
+  PARAMS_FIRST_SIGNATURES = [[:params], [:_params], [:_]].freeze
+
   def call(params, context)
-    context_args = context.values_at(*call_args(@callable, types: %i[req opt]))
-    operation_result = callable.call(*context_args, **params)
+    arg_names = call_args(@callable, types: %i[req opt])
+
+    operation_result = if PARAMS_FIRST_SIGNATURES.include?(arg_names)
+      callable.call(params, **context)
+    else
+      context_args = context.values_at(*arg_names)
+      callable.call(*context_args, **params)
+    end
+
     result = result(params: params, context: context)
 
     if operation_result.failure?

--- a/spec/operations/components/operation_spec.rb
+++ b/spec/operations/components/operation_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Operations::Components::Operation do
   subject(:component) { described_class.new(operation, message_resolver: message_resolver) }
 
-  let(:operation) { ->(entity, **params) { Dry::Monads::Success({ passed: [entity, params] }) } }
+  let(:operation) { ->(params, entity:, **) { Dry::Monads::Success({ passed: [entity, params] }) } }
   let(:message_resolver) { Operations::Contract::MessagesResolver.new(backend) }
   let(:backend) { Dry::Schema::Messages::YAML.build.merge(translations) }
   let(:translations) do
@@ -40,6 +40,22 @@ RSpec.describe Operations::Components::Operation do
             errors: have_attributes(
               to_h: { nil => [{ text: "Failure", code: :failure }] }
             )
+          )
+      end
+    end
+
+    context "when params as kwargs" do
+      let(:operation) { ->(entity, **params) { Dry::Monads::Success({ passed: [entity, params] }) } }
+
+      it "merges the returned result to the context" do
+        expect(call)
+          .to be_success
+          .and have_attributes(
+            component: :operation,
+            params: { name: "Batman" },
+            context: { subject: 42, entity: "Entity", passed: ["Entity", { name: "Batman" }] },
+            after: [],
+            errors: be_empty
           )
       end
     end


### PR DESCRIPTION
Want to bring command components to a single arguments signature. Operation body is the only component left, so this PR fixes it.

Before it was `def call(context1, context2, param1:, param2:, **)`
Now it also allows `def call(params, context1:, context2:, **)` as well. Like any other component.
Alternative signatures:
`def call(_params, context1:, context2:, **)`
`def call(_, context1:, context2:, **)`

The previous way is soft-deprecated and will be removed eventually, so please fix the method signature whenever you see it in the code.