### PR TITLE
Use after_commit instead of transaction for callbacks

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,8 +2,7 @@
 
 %w[5.2 6.0 6.1 7.0].each do |version|
   appraise "rails.#{version}" do
-    gem "activesupport", "~> #{version}.0"
-    gem "activemodel", "~> #{version}.0"
     gem "activerecord", "~> #{version}.0"
+    gem "activesupport", "~> #{version}.0"
   end
 end

--- a/gemfiles/rails.5.2.gemfile
+++ b/gemfiles/rails.5.2.gemfile
@@ -8,8 +8,7 @@ gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rspec", require: false
-gem "activesupport", "~> 5.2.0"
-gem "activemodel", "~> 5.2.0"
 gem "activerecord", "~> 5.2.0"
+gem "activesupport", "~> 5.2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails.6.0.gemfile
+++ b/gemfiles/rails.6.0.gemfile
@@ -8,8 +8,7 @@ gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rspec", require: false
-gem "activesupport", "~> 6.0.0"
-gem "activemodel", "~> 6.0.0"
 gem "activerecord", "~> 6.0.0"
+gem "activesupport", "~> 6.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rails.6.1.gemfile
+++ b/gemfiles/rails.6.1.gemfile
@@ -8,8 +8,7 @@ gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rspec", require: false
-gem "activesupport", "~> 6.1.0"
-gem "activemodel", "~> 6.1.0"
 gem "activerecord", "~> 6.1.0"
+gem "activesupport", "~> 6.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails.7.0.gemfile
+++ b/gemfiles/rails.7.0.gemfile
@@ -8,8 +8,7 @@ gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rspec", require: false
-gem "activesupport", "~> 7.0.0"
-gem "activemodel", "~> 7.0.0"
 gem "activerecord", "~> 7.0.0"
+gem "activesupport", "~> 7.0.0"
 
 gemspec path: "../"

--- a/lib/operations/command.rb
+++ b/lib/operations/command.rb
@@ -171,6 +171,7 @@ class Operations::Command
   option :error_reporter, Operations::Types::Nil | Operations::Types.Interface(:call),
     default: proc { Operations.default_config.error_reporter }
   option :transaction, Operations::Types.Interface(:call), default: proc { Operations.default_config.transaction }
+  option :after_commit, Operations::Types.Interface(:call), default: proc { Operations.default_config.after_commit }
 
   # A short-cut to initialize operation by convention:
   #
@@ -325,8 +326,7 @@ class Operations::Command
       component_kwargs = {
         message_resolver: contract.message_resolver,
         info_reporter: info_reporter,
-        error_reporter: error_reporter,
-        transaction: transaction
+        error_reporter: error_reporter
       }
       callable = send(identifier)
 
@@ -335,7 +335,8 @@ class Operations::Command
         ::Operations::Components::Callback.new(
           callable,
           **component_kwargs,
-          callback_type: identifier
+          callback_type: identifier,
+          after_commit: after_commit
         )
       else
         "::Operations::Components::#{identifier.to_s.camelize}".constantize.new(

--- a/lib/operations/components/base.rb
+++ b/lib/operations/components/base.rb
@@ -15,7 +15,6 @@ class Operations::Components::Base
   option :message_resolver, type: Operations::Types.Interface(:call), optional: true
   option :info_reporter, type: Operations::Types::Nil | Operations::Types.Interface(:call), optional: true
   option :error_reporter, type: Operations::Types::Nil | Operations::Types.Interface(:call), optional: true
-  option :transaction, type: Operations::Types.Interface(:call), optional: true
 
   private
 

--- a/lib/operations/components/callback.rb
+++ b/lib/operations/components/callback.rb
@@ -3,7 +3,7 @@
 require "operations/components/base"
 
 # This component handles `on_failure:` and `on_success` callbacks passed to the
-# composite. Every callback entry is called in a separate
+# composite. Every callback entry is called outside of the operation
 # transaction and any exception is rescued here so the
 # result of the whole operation is not affected.
 # If there is a failure in any entry, it is reported with a proc.
@@ -14,6 +14,7 @@ class Operations::Components::Callback < Operations::Components::Base
 
   param :callable, type: Operations::Types::Array.of(Operations::Types.Interface(:call))
   option :callback_type, type: Operations::Types::Coercible::Symbol.constrained(included_in: CALLBACK_TYPES)
+  option :after_commit, type: Operations::Types.Interface(:call)
 
   def call(params, context)
     results = callable.map do |entry|
@@ -31,17 +32,31 @@ class Operations::Components::Callback < Operations::Components::Base
   private
 
   def call_entry(entry, params, **context)
-    args = call_args(entry, types: %i[req opt])
-
-    result = transaction.call do
-      yield(args.one? ? entry.call(params, **context) : entry.call(**context))
-    end
+    result = yield(entry_result(entry, params, **context))
 
     Success(result)
   rescue Dry::Monads::Do::Halt => e
     e.result
   rescue => e
     Failure(e)
+  end
+
+  def entry_result(entry, params, **context)
+    args = call_args(entry, types: %i[req opt])
+
+    if callback_type == :on_success
+      if args.one?
+        after_commit.call { entry.call(params, **context) }
+      else
+        after_commit.call { entry.call(**context) }
+      end
+    else
+      if args.one? # rubocop:disable Style/IfInsideElse
+        entry.call(params, **context)
+      else
+        entry.call(**context)
+      end
+    end
   end
 
   def maybe_report_failure(result)

--- a/lib/operations/configuration.rb
+++ b/lib/operations/configuration.rb
@@ -9,6 +9,7 @@ class Operations::Configuration
   option :info_reporter, Operations::Types.Interface(:call), optional: true
   option :error_reporter, Operations::Types.Interface(:call), optional: true
   option :transaction, Operations::Types.Interface(:call)
+  option :after_commit, Operations::Types.Interface(:call)
 
   def to_h
     self.class.dry_initializer.attributes(self)

--- a/lib/operations/version.rb
+++ b/lib/operations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Operations
-  VERSION = "0.5.1"
+  VERSION = "0.6.0"
 end

--- a/operations.gemspec
+++ b/operations.gemspec
@@ -27,13 +27,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "activerecord", ">= 5.2.0"
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "database_cleaner-active_record"
   spec.add_development_dependency "sqlite3"
 
-  spec.add_runtime_dependency "activemodel", ">= 5.2.0"
+  spec.add_runtime_dependency "activerecord", ">= 5.2.0"
   spec.add_runtime_dependency "activesupport", ">= 5.2.0"
+  spec.add_runtime_dependency "after_commit_everywhere"
   spec.add_runtime_dependency "dry-monads"
   spec.add_runtime_dependency "dry-validation"
   spec.metadata = {

--- a/spec/operations/configuration_spec.rb
+++ b/spec/operations/configuration_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe Operations::Configuration do
 
   let(:error_reporter) { -> {} }
   let(:transaction) { -> {} }
-  let(:options) { { error_reporter: error_reporter, transaction: transaction } }
+  let(:after_commit) { -> {} }
+  let(:options) { { error_reporter: error_reporter, transaction: transaction, after_commit: after_commit } }
 
   describe "#to_h" do
     subject(:to_h) { configuration.to_h }
 
-    it { is_expected.to eq(error_reporter: error_reporter, transaction: transaction) }
+    it { is_expected.to eq(error_reporter: error_reporter, transaction: transaction, after_commit: after_commit) }
   end
 end


### PR DESCRIPTION
The important part here is that on_success/on_failure callbacks are no more wrapped within a transaction. This is done because the callback is actually supposed to implement (or not) its own transaction. This will allow to avoid unnecessary transactions.