### PR TITLE
Make as_json safer and compatible with ActiveSupport

### DIFF
--- a/lib/operations/command.rb
+++ b/lib/operations/command.rb
@@ -147,7 +147,7 @@ class Operations::Command
     end
 
     def sentry_context
-      operation_result.as_json
+      operation_result.as_json(include_command: true)
     end
   end
 
@@ -290,7 +290,7 @@ class Operations::Command
     end
   end
 
-  def as_json
+  def as_json(*)
     {
       **main_components_as_json,
       **form_components_as_json,

--- a/lib/operations/components/callback.rb
+++ b/lib/operations/components/callback.rb
@@ -38,7 +38,7 @@ class Operations::Components::Callback < Operations::Components::Base
     if result.public_send(callback_type).any?(Failure)
       error_reporter&.call(
         "Operation #{callback_type} side-effects went sideways",
-        result: result.as_json
+        result: result.as_json(include_command: true)
       )
     end
 

--- a/lib/operations/components/idempotency.rb
+++ b/lib/operations/components/idempotency.rb
@@ -63,7 +63,7 @@ class Operations::Components::Idempotency < Operations::Components::Prechecks
   def report_failure(result, failed_check)
     info_reporter&.call(
       "Idempotency check failed",
-      result: result.as_json,
+      result: result.as_json(include_command: true),
       failed_check: failed_check.inspect
     )
   end

--- a/lib/operations/result.rb
+++ b/lib/operations/result.rb
@@ -92,16 +92,17 @@ class Operations::Result
     end
   end
 
-  def as_json
-    {
+  def as_json(*, include_command: false, **)
+    hash = {
       component: component,
-      command: operation.as_json,
       params: params,
       context: context_as_json,
       on_success: on_success.as_json,
       on_failure: on_failure.as_json,
       errors: errors(full: true).to_h
     }
+    hash[:command] = operation.as_json if include_command
+    hash
   end
 
   private

--- a/spec/operations/command_spec.rb
+++ b/spec/operations/command_spec.rb
@@ -911,7 +911,7 @@ RSpec.describe Operations::Command do
   end
 
   describe "#as_json" do
-    subject(:as_json) { command.as_json }
+    subject(:as_json) { command.as_json(:ignored_arg, ignored: :kwarg) }
 
     let(:command) { DummyOperation.instance }
     let(:command_implementation) do

--- a/spec/operations/components/on_failure_spec.rb
+++ b/spec/operations/components/on_failure_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Operations::Components::OnFailure do
         )
       expect(error_reporter).to have_received(:call).with(
         "Operation on_failure side-effects went sideways",
-        result: call.as_json
+        result: call.as_json(include_command: true)
       ).once
     end
   end

--- a/spec/operations/components/on_success_spec.rb
+++ b/spec/operations/components/on_success_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Operations::Components::OnSuccess do
       expect(after_commit).to have_received(:call).once
       expect(error_reporter).to have_received(:call).with(
         "Operation on_success side-effects went sideways",
-        result: call.as_json
+        result: call.as_json(include_command: true)
       ).once
     end
   end

--- a/spec/operations/result_spec.rb
+++ b/spec/operations/result_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Operations::Result do
   end
 
   describe "#as_json" do
-    subject(:as_json) { result.as_json }
+    subject(:as_json) { result.as_json(:ignored_arg, ignored: :kwarg) }
 
     let(:traceable_object) { Struct.new(:id, :name) }
     let(:anonymous_object) { Struct.new(:name) }
@@ -253,7 +253,6 @@ RSpec.describe Operations::Result do
     specify do
       expect(as_json).to include(
         component: :contract,
-        command: command_json,
         params: { id: 123, name: "Jon", lastname: "Snow" },
         context: { record: "TraceableObject#1", object: "AnonymousObject" },
         on_success: match([
@@ -266,6 +265,28 @@ RSpec.describe Operations::Result do
         ]),
         errors: { "column" => ["Error message"] }
       )
+    end
+
+    context "when include_command: true" do
+      subject(:as_json) { result.as_json(include_command: true) }
+
+      specify do
+        expect(as_json).to include(
+          component: :contract,
+          command: command_json,
+          params: { id: 123, name: "Jon", lastname: "Snow" },
+          context: { record: "TraceableObject#1", object: "AnonymousObject" },
+          on_success: match([
+            { "value" => { "Entity" => "Model#1" } },
+            include("trace", "value" => { "additional" => "value" })
+          ]),
+          on_failure: match([
+            { "value" => { "Entity" => "Model#1" } },
+            include("trace", "value" => { "additional" => "value" })
+          ]),
+          errors: { "column" => ["Error message"] }
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Sometime, controllers can render operation_result.as_json which disclosures too much . Making it safer with this PR. And also, in AS `as_json` should support options.