### PR TITLE
Include Dry::Monads[:result] for Policies, Preconditions, Callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Include `Dry::Monads[:result]` in Policies, Preconditions and Callbacks
 - Add `callback` method to `Operations::Convenience` [\#37](https://github.com/BookingSync/operations/pull/37) ([pyromaniac](https://github.com/pyromaniac))
 - Ability to access operation result in callbacks [\#36](https://github.com/BookingSync/operations/pull/36) ([pyromaniac](https://github.com/pyromaniac))
 - Introduce Command#merge [\#34](https://github.com/BookingSync/operations/pull/34) ([pyromaniac](https://github.com/pyromaniac))

--- a/lib/operations/convenience.rb
+++ b/lib/operations/convenience.rb
@@ -88,7 +88,12 @@ module Operations::Convenience
       raise ArgumentError.new("Please provide either a superclass or a block for #{kind}") unless from || block
 
       klass = Class.new(from)
-      klass.extend(Dry::Initializer) unless from
+
+      unless from
+        klass.extend(Dry::Initializer)
+        klass.include(Dry::Monads[:result])
+      end
+
       klass.define_method(:call, &block) if block
 
       const_set("#{prefix.to_s.camelize}#{kind.camelize}", klass)


### PR DESCRIPTION
We've stumbled upon a case when a monad result needs to be returned early in a callback body. So that `Success()` would be available within Callback instanced.