### PR TITLE
Adjust extending Dry::Initializer & including Dry::Monads[:result]

### DIFF
--- a/lib/operations/convenience.rb
+++ b/lib/operations/convenience.rb
@@ -89,7 +89,7 @@ module Operations::Convenience
 
       klass = Class.new(from)
 
-      unless from
+      if from == Object
         klass.extend(Dry::Initializer)
         klass.include(Dry::Monads[:result])
       end


### PR DESCRIPTION
A follow-up on #38 which didn't work as intended.
Since `from` defaults to `Object` and it's unlikely to have `nil` there, for such `Object`s we want to have `Dry::Initializer` as well as `Dry::Monads[:result]`