### PR TITLE
Rename Operations::Form#model_name option to param_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [main](https://github.com/BookingSync/operations/tree/main)
+
+### Changes
+
+- Rename Operations::Form#model_name parameter to param_key and make it public preserving backwards compatibility. [\#52](https://github.com/BookingSync/operations/pull/52) ([pyromaniac](https://github.com/pyromaniac))
+
 ## [0.7.2](https://github.com/BookingSync/operations/tree/v0.7.2)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -952,7 +952,7 @@ class Post::Update
   def self.default_form
     @default_form ||= Operations::Form.new(
       default,
-      model_name: "custom_post_update_form", # form name can be customized
+      param_key: "custom_post_update_form", # form param key can be customized
     )
   end
 end

--- a/lib/operations/form/builder.rb
+++ b/lib/operations/form/builder.rb
@@ -11,27 +11,27 @@ class Operations::Form::Builder
 
   option :base_class, Operations::Types::Instance(Class)
 
-  def build(key_map:, model_map:, namespace: nil, class_name: nil, model_name: nil, persisted: nil)
+  def build(key_map:, model_map:, namespace: nil, class_name: nil, param_key: nil, persisted: nil)
     return namespace.const_get(class_name) if namespace && class_name && namespace.const_defined?(class_name)
 
-    traverse(key_map, model_map, namespace, class_name, model_name, [], persisted: persisted)
+    traverse(key_map, model_map, namespace, class_name, param_key, [], persisted: persisted)
   end
 
   private
 
-  def traverse(key_map, model_map, namespace, class_name, model_name, path, persisted: nil)
+  def traverse(key_map, model_map, namespace, class_name, param_key, path, persisted: nil)
     form = Class.new(base_class)
     namespace.const_set(class_name, form) if namespace&.name && class_name
-    define_model_name(form, model_name) if model_name && !form.name
+    define_model_name(form, param_key) if param_key && !form.name
     form.persisted = persisted
 
     key_map.each { |key| define_attribute(form, model_map, key, path) }
     form
   end
 
-  def define_model_name(form, model_name)
+  def define_model_name(form, param_key)
     form.define_singleton_method :model_name do
-      @model_name ||= ActiveModel::Name.new(self, nil, model_name)
+      @model_name ||= ActiveModel::Name.new(self, nil, param_key)
     end
   end
 

--- a/spec/operations/form/builder_spec.rb
+++ b/spec/operations/form/builder_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe Operations::Form::Builder do
       let(:model_map_hash) { { ["name"] => "Dummy1", ["translations", %r{singular|plural}] => "Dummy2" } }
       let(:model_map) { Operations::Form::DeprecatedLegacyModelMapImplementation.new(model_map_hash) }
 
-      context "with model_name" do
-        let(:options) { { model_name: "my_form" } }
+      context "with param_key" do
+        let(:options) { { param_key: "my_form" } }
 
         it "defines attributes tree correctly" do
           expect(form_class).to have_attributes(

--- a/spec/operations/form_spec.rb
+++ b/spec/operations/form_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Operations::Form do
     let(:context) { {} }
     let(:options) do
       default_options.merge(
-        model_name: "dummy_form",
+        param_key: "dummy_form",
         params_transformations: lambda { |_form_class, params, **_context|
           params.transform_keys { |key| key == :alias_name ? :name : key }
         }
@@ -168,7 +168,7 @@ RSpec.describe Operations::Form do
     specify do
       expect(pretty_inspect.gsub(%r{Proc:0x[^>]+}, "Proc:0x")).to eq(<<~INSPECT)
         #<Operations::Form
-         model_name="dummy_operation_form",
+         param_key="dummy_operation_form",
          model_map=#<Proc:0x>,
          persisted=true,
          params_transformations=[],


### PR DESCRIPTION
This name better reflects the purpose and the use-case